### PR TITLE
Update for PyPi readiness

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,61 @@
+from setuptools import setup, find_packages
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the relevant file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='tapylib',
+
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='0.1',
+
+    description='Python lib for interacting with an instance of the Tapis API Framework',
+    long_description=long_description,
+
+    # The project's main homepage.
+    url='https://github.com/tapis-project/python-sdk',
+
+    # Author details
+    author='Joe Stubbs',
+    author_email='jstubbs@tacc.utexas.edu',
+
+    # Choose your license
+    license='BSD',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 2 - Pre-Alpha',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: BSD License',
+
+        'Natural Language :: English',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+    ],
+
+    # What does your project relate to?
+    keywords='tapis python sdk',
+
+    # List run-time dependencies here.
+    install_requires=['certifi', 'python_dateutil', 'six', 'setuptools', 'urllib3'],
+
+)

--- a/tapy/dyna/dynatapy.py
+++ b/tapy/dyna/dynatapy.py
@@ -1,3 +1,4 @@
+from os import path
 from base64 import b64encode
 from collections.abc import Sequence
 import datetime
@@ -52,7 +53,8 @@ def _getspec(resource_name, resource_url, download_spec=False):
     try:
         # for now, hardcode the paths; we could look these up based on a canonical URL once that is
         # established.
-        spec_path = f'/home/tapis/tapy/dyna/resources/openapi_v3-{resource_name}.yml'
+        resources_dir = path.join(path.dirname(__file__), 'resources')
+        spec_path = f'{resources_dir}/openapi_v3-{resource_name}.yml'
         spec_dict = yaml.load(open(spec_path, 'r'))
         return create_spec(spec_dict)
     except Exception as e:


### PR DESCRIPTION
Someone should look over setup.py for correctness.
Changed some hard coded resource files to get path from `__path__`.
Now able to be installed with `pip3 -e git://github.com/NotChristianGarcia/python-sdk#egg=tapylib`